### PR TITLE
✨ 강의 계획서 개선 및 에브리타임 강의평 정보 연동

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Fixed] 수강인원 조회 기능이 동작하지 않던 오류를 해결했습니다. (https://github.com/klas-helper/klas-helper-extension/issues/16)
 - [Fixed] 빠졌던 기능인 검색어 없이 강의를 검색할 수 있는 기능을 추가했습니다.
 - [Added] 졸업가부 및 졸업불가사유 확인 메뉴를 추가했습니다.
+- [Added] 강의 계획서 개선 및 에브리타임 강의평 정보 연동 기능이 추가되었습니다. (https://github.com/klas-helper/klas-helper-extension/pull/24)
 
 ## 2.0.3.0 (2023.06.25)
 - [Fixed] KLAS 구조 변경으로 인해 작동하지 않던 일부 기능(강의계획서 수강인원 조회 등)을 수정하였습니다.

--- a/src/apis/fetchCommonSubjects.ts
+++ b/src/apis/fetchCommonSubjects.ts
@@ -1,0 +1,31 @@
+export interface CommonSubject {
+  code: string;
+  name: string;
+}
+
+function parseCommonSubject(data: any): CommonSubject {
+  return {
+    code: data.code,
+    name: data.codeName1,
+  };
+}
+
+/**
+ * 광운대학교의 공통 과목 목록을 가져옵니다.
+ */
+export async function fetchCommonSubjects(): Promise<CommonSubject[]> {
+  const response = await fetch('/std/cps/atnlc/CmmnGamokList.do', {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: '{}',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch common subjects. Status: ${response.status}`);
+  }
+
+  return (await response.json()).map(parseCommonSubject);
+}

--- a/src/apis/fetchDepartments.ts
+++ b/src/apis/fetchDepartments.ts
@@ -1,0 +1,39 @@
+export interface Department {
+  code: string;
+  name: string;
+}
+
+export interface FetchDepartmentsRequestData {
+  year: number | string;
+  semester: string;
+}
+
+function parseDepartment(data: any): Department {
+  return {
+    code: data.classCode,
+    name: data.openMajorName,
+  };
+}
+
+/**
+ * 광운대학교의 학과 목록을 가져옵니다.
+ */
+export async function fetchDepartments(requestData: FetchDepartmentsRequestData): Promise<Department[]> {
+  const response = await fetch('/std/cps/atnlc/CmmnHakgwaList.do', {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      selectYear: requestData.year,
+      selecthakgi: requestData.semester,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch departments. Status: ${response.status}`);
+  }
+
+  return (await response.json()).map(parseDepartment);
+}

--- a/src/apis/fetchLectures.ts
+++ b/src/apis/fetchLectures.ts
@@ -75,21 +75,3 @@ export async function fetchLectures(requestData: FetchLecturesRequestData): Prom
 
   return (await response.json()).map(parseLecture);
 }
-
-// Request data
-// {
-//   "selectSubj": "",
-//   "selectYear": "2023",
-//   "selecthakgi": "2",
-//   "isSearch": "N",
-//   "randomNum": 7483,
-//   "numText": "",
-//   "selectRadio": "my",
-//   "selectText": "",
-//   "selectProfsr": "",
-//   "cmmnGamok": "",
-//   "selecthakgwa": "",
-//   "selectMajor": "",
-//   "selectMajorList": [],
-//   "stopFlag": "N"
-// }

--- a/src/apis/fetchLectures.ts
+++ b/src/apis/fetchLectures.ts
@@ -1,0 +1,95 @@
+export interface Lecture {
+  year: string;
+  semester: string;
+  majorCode: string;
+  grade: string;
+  code: string;
+  classNumber: string;
+  name: string;
+  professorName: string;
+  classification: string;
+  classHours: number;
+  credits: number;
+  contact: string;
+  description: string;
+  isClosed: boolean;
+  introVideoUrl: string;
+}
+
+export interface FetchLecturesRequestData {
+  year: number | string;
+  semester: string;
+  enrollmentStatus: string;
+  lectureName?: string;
+  professorName?: string;
+  commonSubjectCode?: string;
+  departmentCode?: string;
+  majorCode?: string;
+}
+
+function parseLecture(data: any): Lecture {
+  return {
+    year: data.thisYear,
+    semester: data.hakgi,
+    majorCode: data.openMajorCode,
+    grade: data.openGrade,
+    code: data.openGwamokNo,
+    classNumber: data.bunbanNo,
+    name: data.gwamokKname,
+    professorName: data.memberName,
+    classification: data.codeName1,
+    classHours: data.sisuNum,
+    credits: data.hakjumNum,
+    contact: data.telNo ?? '',
+    description: data.summary ?? '',
+    isClosed: Boolean(data.closeOpt),
+    introVideoUrl: data.videoUrl ?? '',
+  };
+}
+
+/**
+ * 광운대학교의 강의 목록을 가져옵니다.
+ */
+export async function fetchLectures(requestData: FetchLecturesRequestData): Promise<Lecture[]> {
+  const response = await fetch('/std/cps/atnlc/LectrePlanStdList.do', {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      selectYear: requestData.year,
+      selecthakgi: requestData.semester,
+      selectRadio: requestData.enrollmentStatus,
+      selectText: requestData.lectureName ?? '',
+      selectProfsr: requestData.professorName ?? '',
+      cmmnGamok: requestData.commonSubjectCode ?? '',
+      selecthakgwa: requestData.departmentCode ?? '',
+      selectMajor: requestData.majorCode ?? '',
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch lectures. Status: ${response.status}`);
+  }
+
+  return (await response.json()).map(parseLecture);
+}
+
+// Request data
+// {
+//   "selectSubj": "",
+//   "selectYear": "2023",
+//   "selecthakgi": "2",
+//   "isSearch": "N",
+//   "randomNum": 7483,
+//   "numText": "",
+//   "selectRadio": "my",
+//   "selectText": "",
+//   "selectProfsr": "",
+//   "cmmnGamok": "",
+//   "selecthakgwa": "",
+//   "selectMajor": "",
+//   "selectMajorList": [],
+//   "stopFlag": "N"
+// }

--- a/src/apis/fetchMajors.ts
+++ b/src/apis/fetchMajors.ts
@@ -1,0 +1,41 @@
+export interface Major {
+  code: string;
+  name: string;
+}
+
+export interface FetchMajorsRequestData {
+  year: number | string;
+  semester: string;
+  departmentCode: string;
+}
+
+function parseMajor(data: any): Major {
+  return {
+    code: data.code,
+    name: data.codeName1,
+  };
+}
+
+/**
+ * 광운대학교의 전공 목록을 가져옵니다.
+ */
+export async function fetchMajors(requestData: FetchMajorsRequestData): Promise<Major[]> {
+  const response = await fetch('/std/cps/atnlc/CmmnMagerCodeList.do', {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      selectYear: requestData.year,
+      selecthakgi: requestData.semester,
+      selecthakgwa: requestData.departmentCode,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch majors. Status: ${response.status}`);
+  }
+
+  return (await response.json()).map(parseMajor);
+}

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,4 @@
+export * from './fetchCommonSubjects';
+export * from './fetchDepartments';
+export * from './fetchLectures';
+export * from './fetchMajors';

--- a/src/components/UniversitySyllabus/UniversitySyllabus.scss
+++ b/src/components/UniversitySyllabus/UniversitySyllabus.scss
@@ -1,0 +1,48 @@
+.helper-form {
+  .helper-title {
+    margin-bottom: 4px;
+    font-weight: bold;
+  }
+
+  .helper-control {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    height: 32px;
+  }
+}
+
+.helper-table {
+  th {
+    white-space: pre-line;
+  }
+
+  tbody {
+    tr.ant-table-row {
+      cursor: pointer;
+    }
+
+    td {
+      font-weight: normal;
+    }
+  }
+
+  .helper-missing {
+    background-color: #f5f5f5;
+    color: gray;
+  }
+
+  .helper-closed {
+    background-color: #fef2f2;
+    color: red;
+  }
+
+  .helper-rate {
+    font-size: 14px;
+
+    li {
+      margin: 0 !important;
+      cursor: pointer !important;
+    }
+  }
+}

--- a/src/components/UniversitySyllabus/UniversitySyllabus.tsx
+++ b/src/components/UniversitySyllabus/UniversitySyllabus.tsx
@@ -1,0 +1,353 @@
+import { type EverytimeLecture, everytimeLectures } from '@klas-helper/data';
+import { Button, Card, Col, ConfigProvider, Empty, Input, Radio, Rate, Row, Select, Table, message } from 'antd';
+import { useEffect, useMemo, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import {
+  type CommonSubject,
+  type Department,
+  type FetchLecturesRequestData,
+  type Lecture,
+  type Major,
+  fetchCommonSubjects,
+  fetchDepartments,
+  fetchLectures,
+  fetchMajors,
+} from '../../apis';
+import './UniversitySyllabus.scss';
+
+const currentYear = new Date().getFullYear();
+const currentSemester = new Date().getMonth() < 7 ? '1' : '2';
+
+export function UniversitySyllabus() {
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const { control, watch, handleSubmit } = useForm<FetchLecturesRequestData>({
+    defaultValues: {
+      year: currentYear.toString(),
+      semester: currentSemester,
+      enrollmentStatus: 'all',
+      commonSubjectCode: '',
+      departmentCode: '',
+      majorCode: '',
+    },
+  });
+
+  const watchedDepartmentCode = watch('departmentCode') ?? '';
+
+  const [commonSubjects, setCommonSubjects] = useState<CommonSubject[]>([]);
+  const [departments, setDepartments] = useState<Department[]>([]);
+  const [majors, setMajor] = useState<Major[]>([]);
+
+  // 초기 데이터 가져오기
+  useEffect(() => {
+    fetchCommonSubjects().then(setCommonSubjects);
+    fetchDepartments({ year: currentYear, semester: currentSemester }).then(setDepartments);
+  }, []);
+
+  // 학과 변경 시 전공 목록 가져오기
+  useEffect(() => {
+    fetchMajors({ year: currentYear, semester: currentSemester, departmentCode: watchedDepartmentCode }).then(setMajor);
+  }, [watchedDepartmentCode]);
+
+  const [lectures, setLectures] = useState<Lecture[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // 에브리타임 강의평 데이터 가져오기
+  const everytimeLecturesMap = useMemo(() => {
+    const map = new Map<string, EverytimeLecture>();
+
+    for (const everytimeLecture of everytimeLectures) {
+      map.set(`${everytimeLecture.name}-${everytimeLecture.professor}`, everytimeLecture);
+    }
+
+    return map;
+  }, []);
+
+  const transformedLectures = lectures.map((lecture) => ({
+    ...lecture,
+    key: `${lecture.majorCode}-${lecture.grade}-${lecture.code}-${lecture.classNumber}`,
+    creditsAndClassHours: `${lecture.credits} / ${lecture.classHours}`,
+    everytimeLecture: everytimeLecturesMap.get(`${lecture.name}-${lecture.professorName}`) ?? null,
+  }));
+
+  const onSubmit = handleSubmit(async (data) => {
+    // 서버 부하 문제로 모든 강의 계획서 검색 금지
+    if (data.enrollmentStatus === 'all' && !data.lectureName && !data.professorName && !data.commonSubjectCode && !data.departmentCode) {
+      messageApi.error('과목명 또는 교수명을 입력하지 않은 경우 반드시 공통 과목이나 학과를 선택하셔야 합니다');
+      return;
+    }
+
+    setIsLoading(true);
+
+    const respondedLectures = await fetchLectures(data);
+
+    setLectures(respondedLectures);
+    setIsLoading(false);
+  });
+
+  return (
+    <ConfigProvider
+      theme={{
+        token: {
+          colorBorderSecondary: '#dfdfdf',
+          colorTextDisabled: 'rgba(0, 0, 0, 0.4)',
+        },
+        components: {
+          Table: {
+            headerBg: '#f5f5f5',
+          },
+        },
+      }}
+    >
+      {contextHolder}
+      <form className="helper-form" onSubmit={onSubmit}>
+        <Card>
+          <Row gutter={[28, 20]}>
+            <Col span={12}>
+              <label className="helper-title">년도 / 학기</label>
+              <div className="helper-control">
+                <Controller
+                  control={control}
+                  name="year"
+                  render={({ field }) => (
+                    <Select
+                      style={{ width: 120 }}
+                      options={Array.from({ length: 11 }).map((_, index) => ({
+                        value: `${currentYear - index}`,
+                        label: `${currentYear - index}년`,
+                      }))}
+                      {...field}
+                    />
+                  )}
+                />
+                <Controller
+                  control={control}
+                  name="semester"
+                  render={({ field }) => (
+                    <Select
+                      style={{ width: 120 }}
+                      options={[
+                        { value: '1', label: '1학기' },
+                        { value: '3', label: '여름학기' },
+                        { value: '2', label: '2학기' },
+                        { value: '4', label: '겨울학기' },
+                      ]}
+                      {...field}
+                    />
+                  )}
+                />
+              </div>
+            </Col>
+            <Col span={12}>
+              <label className="helper-title">수강 여부</label>
+              <div className="helper-control">
+                <Controller
+                  control={control}
+                  name="enrollmentStatus"
+                  render={({ field }) => (
+                    <Radio.Group {...field}>
+                      <Radio value="all">전체</Radio>
+                      <Radio value="my">내 과목</Radio>
+                    </Radio.Group>
+                  )}
+                />
+              </div>
+            </Col>
+            <Col span={12}>
+              <label className="helper-title">과목명</label>
+              <div className="helper-control">
+                <Controller
+                  control={control}
+                  name="lectureName"
+                  render={({ field }) => <Input {...field} />}
+                />
+              </div>
+            </Col>
+            <Col span={12}>
+              <label className="helper-title">교수명</label>
+              <div className="helper-control">
+                <Controller
+                  control={control}
+                  name="professorName"
+                  render={({ field }) => <Input {...field} />}
+                />
+              </div>
+            </Col>
+            <Col span={8}>
+              <label className="helper-title">공통 과목</label>
+              <div className="helper-control">
+                <Controller
+                  control={control}
+                  name="commonSubjectCode"
+                  render={({ field }) => (
+                    <Select
+                      style={{ width: '100%' }}
+                      options={[
+                        { value: '', label: '- 전체 -' },
+                        ...commonSubjects.map((item) => ({ value: item.code, label: item.name })),
+                      ]}
+                      {...field}
+                    />
+                  )}
+                />
+              </div>
+            </Col>
+            <Col span={8}>
+              <label className="helper-title">학과</label>
+              <div className="helper-control">
+                <Controller
+                  control={control}
+                  name="departmentCode"
+                  render={({ field }) => (
+                    <Select
+                      style={{ width: '100%' }}
+                      options={[
+                        { value: '', label: '- 전체 -' },
+                        ...departments.map((item) => ({ value: item.code, label: item.name })),
+                      ]}
+                      {...field}
+                    />
+                  )}
+                />
+              </div>
+            </Col>
+            <Col span={8}>
+              <label className="helper-title">전공</label>
+              <div className="helper-control">
+                <Controller
+                  control={control}
+                  name="majorCode"
+                  render={({ field }) => (
+                    <Select
+                      style={{ width: '100%' }}
+                      options={[
+                        { value: '', label: '- 전체 -' },
+                        ...majors.map((item) => ({ value: item.code, label: item.name })),
+                      ]}
+                      {...field}
+                    />
+                  )}
+                />
+              </div>
+            </Col>
+          </Row>
+        </Card>
+        <div style={{ display: 'flex', justifyContent: 'right', marginTop: 8 }}>
+          <Button type="primary" htmlType="submit">조회</Button>
+        </div>
+        <div style={{ marginTop: 32 }}>
+          <Table
+            className="helper-table"
+            columns={[
+              { title: '학정번호', dataIndex: 'key', align: 'center' },
+              {
+                title: '과목명',
+                dataIndex: 'name',
+                align: 'center',
+                render: (name: string, lecture) => {
+                  if (!lecture.description) {
+                    return `${name} (미입력)`;
+                  }
+
+                  if (lecture.isClosed) {
+                    return `${name} (폐강)`;
+                  }
+
+                  return name;
+                },
+              },
+              { title: '이수 구분', dataIndex: 'classification', align: 'center' },
+              { title: '학점 / 시간', dataIndex: 'creditsAndClassHours', align: 'center' },
+              { title: '교수명', dataIndex: 'professorName', align: 'center' },
+              { title: '연락처', dataIndex: 'contact', align: 'center' },
+              {
+                title: '강의평 (everytime.kr)\n과제 / 조모임 / 성적',
+                dataIndex: 'everytimeLecture',
+                align: 'center',
+                render: (everytimeLecture: EverytimeLecture | null) => {
+                  if (!everytimeLecture || everytimeLecture.rate.count < 5) {
+                    return '-';
+                  }
+
+                  const assignments = [...(everytimeLecture.details.find((detail) => detail.name === '과제')?.items ?? [])];
+                  const teamProjects = [...(everytimeLecture.details.find((detail) => detail.name === '조모임')?.items ?? [])];
+                  const scores = [...(everytimeLecture.details.find((detail) => detail.name === '성적')?.items ?? [])];
+
+                  const assignmentText = assignments.sort((a, b) => b.count - a.count)[0]?.text ?? '-';
+                  const teamProjectText = teamProjects.sort((a, b) => b.count - a.count)[0]?.text ?? '-';
+                  const scoreText = scores.sort((a, b) => b.count - a.count)[0]?.text ?? '-';
+
+                  return (
+                    <div>
+                      <div style={{ display: 'flex', justifyContent: 'center', gap: 8 }}>
+                        <Rate
+                          className="helper-rate"
+                          defaultValue={everytimeLecture.rate.average}
+                          disabled={true}
+                          allowHalf={true}
+                        />
+                        <a
+                          href={`https://everytime.kr/lecture/view/${everytimeLecture.id}`}
+                          target="_blank"
+                          rel="noreferrer"
+                          onClick={(event) => event.stopPropagation()}
+                        >
+                          🔗
+                        </a>
+                      </div>
+                      <div>
+                        {`${assignmentText} / ${teamProjectText} / ${scoreText}`}
+                      </div>
+                    </div>
+                  );
+                },
+              },
+            ]}
+            dataSource={transformedLectures}
+            loading={isLoading}
+            rowClassName={(lecture) => {
+              if (!lecture.description) {
+                return 'helper-missing';
+              }
+
+              if (lecture.isClosed) {
+                return 'helper-closed';
+              }
+
+              return '';
+            }}
+            size="small"
+            pagination={false}
+            bordered={true}
+            locale={{
+              emptyText: () => (
+                <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} description="조회된 데이터가 없습니다" />
+              ),
+            }}
+            onRow={(lecture) => ({
+              onClick: () => {
+                if (!lecture.description) {
+                  messageApi.info('강의 계획서 정보가 없습니다');
+                  return;
+                }
+
+                if (lecture.isClosed) {
+                  messageApi.info('폐강된 강의입니다');
+                  return;
+                }
+
+                const id = `U${lecture.year}${lecture.semester}${lecture.code}${lecture.majorCode}${lecture.classNumber}${lecture.grade}`;
+
+                window.open(
+                  `https://klas.kw.ac.kr/std/cps/atnlc/popup/LectrePlanStdView.do?selectSubj=${id}`,
+                  '',
+                  'width=1000, height=800, scrollbars=yes'
+                );
+              },
+            })}
+          />
+        </div>
+      </form>
+    </ConfigProvider>
+  );
+}

--- a/src/components/UniversitySyllabus/index.ts
+++ b/src/components/UniversitySyllabus/index.ts
@@ -1,0 +1,1 @@
+export { UniversitySyllabus } from './UniversitySyllabus';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from './UniversitySyllabus';

--- a/src/routes/syllabus.tsx
+++ b/src/routes/syllabus.tsx
@@ -3,6 +3,12 @@
  * 페이지 주소: https://klas.kw.ac.kr/std/cps/atnlc/LectrePlanStdPage.do
  */
 
+import { createRoot } from 'react-dom/client';
+import { UniversitySyllabus } from '../components';
+
+declare var appModule: any;
+declare var axios: any;
+
 export default () => {
   // 엔터로 강의 계획서 검색
   $('table:nth-of-type(1) input[type="text"]').keydown((event) => {
@@ -10,7 +16,7 @@ export default () => {
   });
 
   // 강의계획서 조회 시 새 창으로 열기
-  appModule.goLectrePlan = function (item) {
+  appModule.goLectrePlan = function (item: any) {
     const selectSubj = 'U' + item.thisYear + item.hakgi + item.openGwamokNo + item.openMajorCode + item.bunbanNo + item.openGrade;
 
     if (item.closeOpt === 'Y') {
@@ -23,7 +29,7 @@ export default () => {
     }
 
     axios.post('CultureOptOneInfo.do', appModule.$data)
-      .then(function (response) {
+      .then(function (response: any) {
         if (!Boolean(response.data.cultureOpt)) {
           window.open('https://klas.kw.ac.kr/std/cps/atnlc/popup/LectrePlanStdView.do?selectSubj=' + selectSubj, '', 'width=1000, height=800, scrollbars=yes, title=강의계획서 조회');
         }
@@ -51,8 +57,47 @@ export default () => {
     }
 
     // 데이터 요청
-    axios.post('LectrePlanStdList.do', this.$data).then((response) => {
+    axios.post('LectrePlanStdList.do', this.$data).then((response: any) => {
       this.list = response.data;
     });
   };
+
+  // 이전 버전 강의 계획서로 되돌리는 기능 추가
+  createOldVersionControl();
+
+  // 신규 강의 계획서 리액트 렌더링
+  $('.con_tab').after('<div id="react-app"></div>');
+  createRoot(document.getElementById('react-app')!).render(<UniversitySyllabus />);
 };
+
+function createOldVersionControl() {
+  // 스타일 추가
+  $('#appModule > div:first-of-type')
+    .css('display', 'flex')
+    .css('align-items', 'center')
+    .css('justify-content', 'space-between');
+
+  // 체크박스 추가
+  $('.contenttitle').after(`
+    <div>
+      <input type="checkbox" id="old-version">
+        <label for="old-version" style="font-size: 16px;">이전 버전으로 보기</label>
+      </input>
+    </div>
+  `);
+
+  // 체크박스 이벤트 추가
+  $('#old-version').change(function () {
+    if ($(this).prop('checked')) {
+      $('#react-app').css('display', 'none');
+      $('#appModule > div > .card').css('display', 'block');
+    }
+    else {
+      $('#react-app').css('display', 'block');
+      $('#appModule > div > .card').css('display', 'none');
+    }
+  });
+
+  // 이전 버전 강의 계획서는 기본적으로 숨김
+  $('#appModule > div > .card').css('display', 'none');
+}


### PR DESCRIPTION
https://github.com/klas-helper/klas-helper-extension/issues/20 해당 이슈에서 논의되었던 강의 계획서에 에브리타임 강의평 정보를 연동하는 기능이 완성되었습니다. 원래는 기존의 기능이나 디자인에서 크게 변동 없이 에브리타임 강의평 정보만 그대로 추가하려고 했으나, 이를 기존의 코드에 이식하는 것이 거의 불가능에 가까운 것 같아서 React를 이용해서 강의 계획서를 새로 만들어 버렸습니다. 😂

## 변경 사항

### 사용자 기준

- 기존의 디자인보다 세련된 강의 계획서를 이용할 수 있습니다.
- 조회 결과에 에브리타임 강의평 정보가 연동됩니다. 기본적으로 평점, 과제, 조모임, 성적 정보를 확인할 수 있으며 🔗 이모지를 클릭할 경우 해당 강의의 에브리타임 강의평 페이지로 이동됩니다.
- 강의 계획서를 새로 만들었다 보니 버그가 발생할 수 있습니다. 이를 대비해 상단의 체크박스로 이전 버전의 강의 계획서도 이용할 수 있습니다.

### 개발자 기준

- React와 SCSS가 도입되었습니다. 이를 이용하면 복잡한 기능과 디자인을 훨씬 편하게 구현할 수 있습니다. (19fc07bde7323920b3b6ccb63ca5263d811a4bb2)
- `apis` 폴더에 강의 계획서와 관련된 정보를 쉽게 가져올 수 있도록 API를 만들었습니다.
- 수집된 에브리타임 강의평 정보는 `@klas-helper/data` 패키지에서 `import` 문으로 쉽게 가져와 사용할 수 있습니다.
- `scripts` 폴더에 에브리타임 강의평 수집 스크립트가 있습니다. 크롬 브라우저의 콘솔 탭에서 해당 스크립트를 실행하면 에브리타임 강의평 정보가 JSON 형태의 데이터로 수집됩니다. 이 과정은 약 1시간 정도 소요됩니다. (be8649b335ab19f8d81f6dd992071269d9db98fa)

## 개선할 점

- 수집된 에브리타임 강의평 정보가 약 3.5MB 정도로 매우 큽니다. PC에서 테스트했을 때에는 크게 체감되지는 않았으나 구형 PC나 모바일 기기에서는 성능 이슈가 발생할 가능성이 있습니다.
- 현재는 모든 페이지에서 에브리타임 강의평 정보를 로드하고 있습니다. 해당 데이터가 필요한 강의 계획서 페이지에서만 데이터를 로드하는 방식으로 성능을 개선할 수 있을 것 같습니다. (아직 방법을 찾지 못했습니다.)

## 스크린샷

### Before

![image](https://github.com/klas-helper/klas-helper-extension/assets/50603255/5522a3ea-6186-4da1-9458-8ed8f16fd307)

### After

![image](https://github.com/klas-helper/klas-helper-extension/assets/50603255/e21df8c2-ec92-4fc9-9351-b881eb80f912)
