### PR TITLE
Firefox 지원 추가

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -60,7 +60,7 @@
     }
   ],
   "background": {
-    "service_worker": "background.js"
+    "scripts": ["background.js"]
   },
   "browser_specific_settings": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -49,7 +49,8 @@
         "assets/css/jquery.modal.min.css",
         "dark.css",
         "app.js",
-        "app.css"
+        "app.css",
+        "data/everytime-lectures.json"
       ]
     },
     {

--- a/packages/data/src/everytime-lectures/index.ts
+++ b/packages/data/src/everytime-lectures/index.ts
@@ -18,4 +18,87 @@ export interface EverytimeLecture {
   details: EverytimeLectureDetail[];
 }
 
-export const everytimeLectures: EverytimeLecture[] = require('./everytime-lectures.json');
+// Runtime loader for everytime lectures data
+let _everytimeLectures: EverytimeLecture[] | null = null;
+let _loadingPromise: Promise<EverytimeLecture[]> | null = null;
+
+/**
+ * Get everytime lectures data with lazy loading
+ * Uses cross-platform compatible approach to load external JSON
+ */
+export async function getEverytimeLectures(): Promise<EverytimeLecture[]> {
+  if (_everytimeLectures !== null) {
+    return _everytimeLectures;
+  }
+
+  if (_loadingPromise !== null) {
+    return _loadingPromise;
+  }
+
+  _loadingPromise = loadEverytimeLecturesData();
+  _everytimeLectures = await _loadingPromise;
+  return _everytimeLectures;
+}
+
+/**
+ * Synchronous getter for everytime lectures (returns empty array if not loaded)
+ * Use getEverytimeLectures() for async loading
+ */
+export function getEverytimeLecturesSync(): EverytimeLecture[] {
+  return _everytimeLectures || [];
+}
+
+/**
+ * Load everytime lectures data from external JSON file
+ * Uses fetch with relative URL that works in both Chrome and Firefox extensions
+ */
+async function loadEverytimeLecturesData(): Promise<EverytimeLecture[]> {
+  try {
+    // Construct URL relative to extension root
+    // This works in both Chrome and Firefox without chrome.runtime.getURL
+    const baseUrl = getExtensionBaseUrl();
+    const dataUrl = `${baseUrl}data/everytime-lectures.json`;
+    const response = await fetch(dataUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to load everytime lectures data: ${response.status}`);
+    }
+    const data: EverytimeLecture[] = await response.json();
+    console.log(`Loaded ${data.length} everytime lectures`);
+    return data;
+  }
+  catch (error) {
+    console.error('Error loading everytime lectures data:', error);
+    // Return empty array as fallback
+    return [];
+  }
+}
+
+/**
+ * Get extension base URL in a cross-platform way
+ */
+function getExtensionBaseUrl(): string {
+  // Try to get the current script URL and derive base from it
+  if (typeof document !== 'undefined') {
+    // In content script context, find extension resources
+    const scripts = document.querySelectorAll('script[src*="app.js"], script[src*="content-main.js"]');
+    for (const script of scripts) {
+      const src = (script as HTMLScriptElement).src;
+      if (src.includes('extension://') || src.includes('moz-extension://')) {
+        // Extract base URL
+        const match = src.match(/(.*:\/\/[^\/]+\/)/);
+        if (match) {
+          return match[1];
+        }
+      }
+    }
+  }
+  // Fallback: try to construct from current location if in extension context
+  if (typeof location !== 'undefined' &&
+      (location.protocol === 'chrome-extension:' || location.protocol === 'moz-extension:')) {
+    return `${location.protocol}//${location.host}/`;
+  }
+  // Last resort: return relative path (may work in some contexts)
+  return './';
+}
+// Backward compatibility: synchronous export (will be empty until loaded)
+export const everytimeLectures: EverytimeLecture[] = getEverytimeLecturesSync();

--- a/src/components/UniversitySyllabus/UniversitySyllabus.tsx
+++ b/src/components/UniversitySyllabus/UniversitySyllabus.tsx
@@ -1,4 +1,4 @@
-import { type EverytimeLecture, everytimeLectures } from '@klas-helper/data';
+import { type EverytimeLecture, getEverytimeLectures } from '@klas-helper/data';
 import { Button, Card, Col, ConfigProvider, Empty, Input, Radio, Rate, Row, Select, Table, message } from 'antd';
 import { useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
@@ -51,17 +51,27 @@ export function UniversitySyllabus() {
 
   const [lectures, setLectures] = useState<Lecture[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [everytimeLecturesData, setEverytimeLecturesData] = useState<EverytimeLecture[]>([]);
 
-  // 에브리타임 강의평 데이터 가져오기
+  // 에브리타임 강의평 데이터 비동기 로딩
+  useEffect(() => {
+    getEverytimeLectures()
+      .then(setEverytimeLecturesData)
+      .catch((error) => {
+        console.error('Failed to load everytime lectures:', error);
+      });
+  }, []);
+
+  // 에브리타임 강의평 데이터 맵 생성
   const everytimeLecturesMap = useMemo(() => {
     const map = new Map<string, EverytimeLecture>();
 
-    for (const everytimeLecture of everytimeLectures) {
+    for (const everytimeLecture of everytimeLecturesData) {
       map.set(`${everytimeLecture.name}-${everytimeLecture.professor}`, everytimeLecture);
     }
 
     return map;
-  }, []);
+  }, [everytimeLecturesData]);
 
   const transformedLectures = lectures.map((lecture) => ({
     ...lecture,

--- a/src/content-main.ts
+++ b/src/content-main.ts
@@ -11,9 +11,9 @@ function jsCache(filePath: string) {
 (async () => {
   // 크롬 sync 스토리지 이용해 체크 여부 확인
   try {
-    browser.storage.sync.get('currentState', function (items) {
+    browser.storage.sync.get('currentState').then((items) => {
       // chrome namespace not supported
-      if (items === undefined) {
+      if (items === undefined || Object.keys(items).length === 0) {
         main();
       }
       else if (items.currentState === undefined) {
@@ -23,6 +23,9 @@ function jsCache(filePath: string) {
       else if (items.currentState === 'ON') {
         main();
       }
+    }).catch((error) => {
+      console.error('Error accessing storage:', error);
+      main();
     });
   }
   catch (e) {

--- a/src/content-style.ts
+++ b/src/content-style.ts
@@ -14,7 +14,7 @@ function main() {
       // 크롬 sync 스토리지 이용해 체크 여부 확인
       try {
         // dark mode 적용
-        browser.storage.sync.get(null, function (items) {
+        browser.storage.sync.get(null).then((items) => {
           // chrome namespace not supported
           if (items.useDark === undefined) {
             browser.storage.sync.set({ 'useDark': 'OFF' });
@@ -27,6 +27,8 @@ function main() {
             style.rel = 'stylesheet';
             document.querySelector('head')?.append(style);
           }
+        }).catch((error) => {
+          console.error('Error accessing storage:', error);
         });
       }
       catch (e) {
@@ -46,9 +48,9 @@ function main() {
 
 // 크롬 sync 스토리지 이용해 체크 여부 확인
 try {
-  browser.storage.sync.get('currentState', function (items) {
+  browser.storage.sync.get('currentState').then((items) => {
     // chrome namespace not supported
-    if (items === undefined) {
+    if (items === undefined || Object.keys(items).length === 0) {
       main();
     }
     else if (items.currentState === undefined) {
@@ -58,6 +60,9 @@ try {
     else if (items.currentState === 'ON') {
       main();
     }
+  }).catch((error) => {
+    console.error('Error accessing storage:', error);
+    main();
   });
 }
 catch (e) {

--- a/src/core/browser.ts
+++ b/src/core/browser.ts
@@ -1,1 +1,1 @@
-export const browser = typeof window !== 'undefined' ? (window.browser || window.chrome) : chrome;
+export const browser = (typeof window !== 'undefined') ? ((typeof window.chrome !== 'undefined' || typeof window.browser !== 'undefined') ? (window.browser || window.chrome) : chrome) : chrome;

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -176,7 +176,7 @@ export const internalPathFunctions = {
     const changeTimeTable = () => {
       const element = document.getElementsByClassName('form-control')[0];
       try {
-        browser.storage.sync.get(null, function (items) {
+        browser.storage.sync.get(null).then((items) => {
           if (items.timeTableIdx === undefined) {
             browser.storage.sync.set({ 'timeTableIdx': 0 });
           }
@@ -184,6 +184,8 @@ export const internalPathFunctions = {
             (element as any).selectedIndex = items.timeTableIdx;
             element.dispatchEvent(new Event('change'));
           }
+        }).catch((error) => {
+          console.error('Error accessing storage:', error);
         });
       }
       catch (e) {

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -13,9 +13,9 @@ if (!darkBtn) {
   throw new Error('Dark button not found');
 }
 
-browser.storage.sync.get(null, function (items) {
+browser.storage.sync.get(null).then((items) => {
   // Toggle button not supprted in Firefox
-  if (items === undefined) {
+  if (items === undefined || Object.keys(items).length === 0) {
     const supportAlert = document.querySelector<HTMLDivElement>('.support-alert');
 
     if (!supportAlert) {
@@ -59,6 +59,10 @@ browser.storage.sync.get(null, function (items) {
   else if (items.useDark === 'ON') {
     darkBtn.checked = true;
   }
+}).catch((error) => {
+  console.error('Error accessing storage:', error);
+  // Fallback behavior
+  activeBtn.checked = true;
 });
 
 activeBtn.onclick = function () {

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -46,6 +46,7 @@ const config: Configuration = {
       patterns: [
         { from: 'public', to: '.' },
         { from: 'manifest.json', to: '.' },
+        { from: 'packages/data/src/everytime-lectures/everytime-lectures.json', to: 'data/everytime-lectures.json' },
       ],
     }),
   ],


### PR DESCRIPTION
2.2.0.0 버전을 기준으로 Firefox에서 작동하도록 코드를 약간 수정했습니다.

manifest.js에서 현재 Firefox에서 backgroun.service_worker를 지원하지 않는 관계로 이 부분을 background.scripts로 변경했고, src/core/browser.ts에서 window.chrome, window.browser 모두 undefined로 확인되어 스크립트가 실행되지 않는 문제가 있어 chrome 객체를 사용하도록 수정했습니다.

Firefox/Chrome 모두 작동하는 것을 확인하였으나 chrome에서는 개발자 모드 기준 "'background.scripts' requires manifest version of 2 or lower." 오류를 내는 것이 확인됩니다. 또, 모든 기능을 확인해보지는 못했고 메인 화면과 강의 세부정보, 강의 재생화면에서 이상이 발생하지 않는 점은 확인했습니다.

제가 TypeScript를 써본 경험이 거의 없어서 최소한의 수정만 진행하였고 이로 인해 코드가 이상할 수 있습니다. 확인 후 처리 부탁드립니다.
감사합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 강의평 데이터 로딩을 지연·비동기로 전환해 초기 로딩 실패 시 빈 화면/에러를 줄였습니다.
  * 저장소 접근 오류나 빈 데이터일 때도 기본값을 적용해 기능이 계속 동작하도록 개선했습니다(확장 활성화, 다크 모드 유지).
  * 다양한 환경에서 브라우저 감지 안정성을 높여 예외/크래시를 감소시켰습니다.
* **Refactor**
  * 스토리지 처리를 프로미스 기반으로 통일하고 오류 처리를 보강했습니다.
  * 강의평 매핑 흐름을 비동기 로딩에 맞게 정비했습니다.
* **Chores**
  * 확장 리소스에 강의 데이터 파일을 포함하고 백그라운드 스크립트 구성을 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->