### PR TITLE
홈 화면에 표시되는 온라인 강의에서 ZOOM 또는 녹화 영상이 없는 항목 제외

### DIFF
--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -161,7 +161,7 @@ export default () => {
         const nowDate = new Date();
 
         for (const lecture of responseData) {
-          if (lecture.evltnSe !== 'lesson' || lecture.prog === 100) {
+          if (lecture.evltnSe !== 'lesson' || lecture.prog === 100 || lecture.isonoff === 'OFF') {
             continue;
           }
 


### PR DESCRIPTION
안녕하세요.

홈화면에서 표시되는 온라인 강좌 중 Zoom (실시간 강의) 링크 또는 영상이 없는 항목을 표시하지 않도록 코드를 변경했습니다.
https://klas.kw.ac.kr/std/lis/evltn/SelectOnlineCntntsStdList.do 에서 가져오는 데이터 중 isonoff 항목을 활용하여 필터링하게 되며 이 항목은 녹화 강의가 있으면 Y, 줌 링크가 등록되어 있으면 ZOOM, 아무 항목도 없으면 OFF 값을 가지는 것으로 확인했고, 확인 과정에서 데이터 필요하시면 업로드하겠습니다.

Firefox 및 Chrome에서 작동 확인했으며 홈 화면 외에도 강의계획서 등 기능 작동을 확인하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * OFF 상태로 표시된 강의가 마감일 계산에서 제외되도록 강의 필터링 로직을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->