### PR TITLE
✨ 수강 과목 현황 과제 칼럼에 퀴즈 포함 및 동적 링크 적용

### DIFF
--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -160,12 +160,18 @@ export default () => {
           selectChangeYn: 'Y',
         }));
 
-        // 퀴즈를 가져올 주소 설정
-        promises.push(axios.post('/std/lis/evltn/QuizStdList.do', {
+        // 퀴즈를 가져올 주소 설정 (실패해도 나머지 데이터에 영향 없도록 catch 처리)
+        promises.push(axios.post('/std/lis/evltn/AnytmQuizStdList.do', {
           selectSubj: subject.subj,
           selectYearhakgi: subject.yearhakgi,
           selectChangeYn: 'Y',
-        }));
+        }).catch(() => ({
+          data: [],
+          config: {
+            url: '/std/lis/evltn/AnytmQuizStdList.do',
+            data: JSON.stringify({ selectSubj: subject.subj }),
+          },
+        })));
       }
 
       // 온라인 강의 파싱 함수
@@ -283,7 +289,7 @@ export default () => {
               parseHomework(subjectCode, response.data, 'TP');
               break;
 
-            case '/std/lis/evltn/QuizStdList.do':
+            case '/std/lis/evltn/AnytmQuizStdList.do':
               parseHomework(subjectCode, response.data, 'QZ');
               break;
           }
@@ -337,7 +343,7 @@ export default () => {
           if (cur.quiz.remainingTime < cur.homework.remainingTime) {
             remainingTime = cur.quiz.remainingTime;
             remainingCount = cur.quiz.remainingCount;
-            url = '/std/lis/evltn/QuizStdPage.do';
+            url = '/std/lis/evltn/AnytmQuizStdPage.do';
           }
           else if (cur.homework.remainingTime < cur.quiz.remainingTime) {
             remainingTime = cur.homework.remainingTime;

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -256,17 +256,35 @@ export default () => {
 
             deadline[subjectCode].teamProject.totalCount++;
           }
-          else if (homeworkType === 'QZ') {
-            if (deadline[subjectCode].quiz.remainingTime > hourGap) {
-              deadline[subjectCode].quiz.remainingTime = hourGap;
-              deadline[subjectCode].quiz.remainingCount = 1;
-            }
-            else if (deadline[subjectCode].quiz.remainingTime === hourGap) {
-              deadline[subjectCode].quiz.remainingCount++;
-            }
+          isExistDeadline = true;
+        }
+      };
 
-            deadline[subjectCode].quiz.totalCount++;
+      // 퀴즈 파싱 함수
+      const parseQuiz = (subjectCode, responseData) => {
+        const nowDate = new Date();
+
+        for (const quiz of responseData) {
+          if (quiz.issubmit === 'Y') {
+            continue;
           }
+
+          const endDate = new Date(quiz.edt);
+          const hourGap = Math.floor((endDate - nowDate) / 3600000);
+
+          if (hourGap < 0) {
+            continue;
+          }
+
+          if (deadline[subjectCode].quiz.remainingTime > hourGap) {
+            deadline[subjectCode].quiz.remainingTime = hourGap;
+            deadline[subjectCode].quiz.remainingCount = 1;
+          }
+          else if (deadline[subjectCode].quiz.remainingTime === hourGap) {
+            deadline[subjectCode].quiz.remainingCount++;
+          }
+
+          deadline[subjectCode].quiz.totalCount++;
           isExistDeadline = true;
         }
       };
@@ -290,7 +308,7 @@ export default () => {
               break;
 
             case '/std/lis/evltn/AnytmQuizStdList.do':
-              parseHomework(subjectCode, response.data, 'QZ');
+              parseQuiz(subjectCode, response.data);
               break;
           }
         }

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -319,7 +319,7 @@ export default () => {
         item.lecture.remainingTime,
         item.homework.remainingTime,
         item.quiz.remainingTime,
-        item.teamProject.remainingTime,
+        item.teamProject.remainingTime
       );
 
       const sortedDeadline = Object.values(deadline).sort((left, right) => {

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -326,6 +326,34 @@ export default () => {
         return getMinTime(left) - getMinTime(right);
       });
 
+      // 테이블 구조 초기화 (재호출 시 중복 방지)
+      $('#yes-deadline colgroup').html(`
+        <col width="21%">
+        <col width="25%">
+        <col width="25%">
+        <col width="25%">
+      `);
+      $('#yes-deadline thead tr').html(`
+        <td></td>
+        <td>온라인 강의</td>
+        <td>과제</td>
+        <td>팀 프로젝트</td>
+      `);
+
+      // 미제출 퀴즈 존재 여부 확인 후 칼럼 동적 추가
+      const hasQuiz = Object.values(deadline).some((d) => d.quiz.totalCount > 0);
+
+      if (hasQuiz) {
+        $('#yes-deadline colgroup').html(`
+          <col width="20%">
+          <col width="20%">
+          <col width="20%">
+          <col width="20%">
+          <col width="20%">
+        `);
+        $('#yes-deadline thead tr td:nth-child(3)').after('<td>퀴즈</td>');
+      }
+
       // 내용 생성 함수
       const createContent = (name, info) => {
         if (info.remainingTime === Infinity) {
@@ -353,31 +381,6 @@ export default () => {
 
       // HTML 코드 생성
       const trCode = sortedDeadline.reduce((acc, cur) => {
-        // 과제 + 퀴즈 병합: 마감이 더 이른 쪽으로 링크 결정
-        const homeworkMerged = (() => {
-          const totalCount = cur.homework.totalCount + cur.quiz.totalCount;
-          let remainingTime, remainingCount, url;
-
-          if (cur.quiz.remainingTime < cur.homework.remainingTime) {
-            remainingTime = cur.quiz.remainingTime;
-            remainingCount = cur.quiz.remainingCount;
-            url = '/std/lis/evltn/AnytmQuizStdPage.do';
-          }
-          else if (cur.homework.remainingTime < cur.quiz.remainingTime) {
-            remainingTime = cur.homework.remainingTime;
-            remainingCount = cur.homework.remainingCount;
-            url = '/std/lis/evltn/TaskStdPage.do';
-          }
-          else {
-            // 동점이거나 둘 다 Infinity(항목 없음)
-            remainingTime = cur.homework.remainingTime;
-            remainingCount = cur.homework.remainingCount + cur.quiz.remainingCount;
-            url = '/std/lis/evltn/TaskStdPage.do';
-          }
-
-          return { remainingTime, remainingCount, totalCount, url };
-        })();
-
         acc += `
            <tr style="border-bottom: 1px solid #dce3eb; height: 30px">
              <td style="font-weight: bold">
@@ -389,10 +392,16 @@ export default () => {
                </span>
              </td>
              <td>
-               <span style="cursor: pointer" onclick="appModule.goLctrumBoard('${homeworkMerged.url}', '${cur.yearSemester}', '${cur.subjectCode}')">
-                 ${createContent('과제', homeworkMerged)}
+               <span style="cursor: pointer" onclick="appModule.goLctrumBoard('/std/lis/evltn/TaskStdPage.do', '${cur.yearSemester}', '${cur.subjectCode}')">
+                 ${createContent('과제', cur.homework)}
                </span>
              </td>
+             ${hasQuiz ? `
+             <td>
+               <span style="cursor: pointer" onclick="appModule.goLctrumBoard('/std/lis/evltn/AnytmQuizStdPage.do', '${cur.yearSemester}', '${cur.subjectCode}')">
+                 ${createContent('퀴즈', cur.quiz)}
+               </span>
+             </td>` : ''}
              <td>
                <span style="cursor: pointer" onclick="appModule.goLctrumBoard('/std/lis/evltn/PrjctStdPage.do', '${cur.yearSemester}', '${cur.subjectCode}')">
                  ${createContent('팀 프로젝트', cur.teamProject)}

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -132,6 +132,11 @@ export default () => {
             remainingCount: 0,
             totalCount: 0,
           },
+          quiz: {
+            remainingTime: Infinity,
+            remainingCount: 0,
+            totalCount: 0,
+          },
         };
 
         // 온라인 강의를 가져올 주소 설정
@@ -150,6 +155,13 @@ export default () => {
 
         // 팀 프로젝트를 가져올 주소 설정
         promises.push(axios.post('/std/lis/evltn/PrjctStdList.do', {
+          selectSubj: subject.subj,
+          selectYearhakgi: subject.yearhakgi,
+          selectChangeYn: 'Y',
+        }));
+
+        // 퀴즈를 가져올 주소 설정
+        promises.push(axios.post('/std/lis/evltn/QuizStdList.do', {
           selectSubj: subject.subj,
           selectYearhakgi: subject.yearhakgi,
           selectChangeYn: 'Y',
@@ -238,6 +250,17 @@ export default () => {
 
             deadline[subjectCode].teamProject.totalCount++;
           }
+          else if (homeworkType === 'QZ') {
+            if (deadline[subjectCode].quiz.remainingTime > hourGap) {
+              deadline[subjectCode].quiz.remainingTime = hourGap;
+              deadline[subjectCode].quiz.remainingCount = 1;
+            }
+            else if (deadline[subjectCode].quiz.remainingTime === hourGap) {
+              deadline[subjectCode].quiz.remainingCount++;
+            }
+
+            deadline[subjectCode].quiz.totalCount++;
+          }
           isExistDeadline = true;
         }
       };
@@ -259,24 +282,24 @@ export default () => {
             case '/std/lis/evltn/PrjctStdList.do':
               parseHomework(subjectCode, response.data, 'TP');
               break;
+
+            case '/std/lis/evltn/QuizStdList.do':
+              parseHomework(subjectCode, response.data, 'QZ');
+              break;
           }
         }
       });
 
       // 마감이 빠른 순으로 정렬
+      const getMinTime = (item) => Math.min(
+        item.lecture.remainingTime,
+        item.homework.remainingTime,
+        item.quiz.remainingTime,
+        item.teamProject.remainingTime,
+      );
+
       const sortedDeadline = Object.values(deadline).sort((left, right) => {
-        const minLeft = left.lecture.remainingTime < left.lecture.remainingTime ? left.lecture : left.homework;
-        const minRight = right.lecture.remainingTime < right.lecture.remainingTime ? right.lecture : right.homework;
-
-        if (minLeft.remainingTime !== minRight.remainingTime) {
-          return minLeft.remainingTime - minRight.remainingTime;
-        }
-
-        if (minLeft.remainingCount !== minRight.remainingCount) {
-          return minRight.remainingCount - minLeft.remainingCount;
-        }
-
-        return (right.lecture.remainingCount + right.homework.remainingCount) - (left.lecture.remainingCount + left.homework.remainingCount);
+        return getMinTime(left) - getMinTime(right);
       });
 
       // 내용 생성 함수
@@ -306,6 +329,31 @@ export default () => {
 
       // HTML 코드 생성
       const trCode = sortedDeadline.reduce((acc, cur) => {
+        // 과제 + 퀴즈 병합: 마감이 더 이른 쪽으로 링크 결정
+        const homeworkMerged = (() => {
+          const totalCount = cur.homework.totalCount + cur.quiz.totalCount;
+          let remainingTime, remainingCount, url;
+
+          if (cur.quiz.remainingTime < cur.homework.remainingTime) {
+            remainingTime = cur.quiz.remainingTime;
+            remainingCount = cur.quiz.remainingCount;
+            url = '/std/lis/evltn/QuizStdPage.do';
+          }
+          else if (cur.homework.remainingTime < cur.quiz.remainingTime) {
+            remainingTime = cur.homework.remainingTime;
+            remainingCount = cur.homework.remainingCount;
+            url = '/std/lis/evltn/TaskStdPage.do';
+          }
+          else {
+            // 동점이거나 둘 다 Infinity(항목 없음)
+            remainingTime = cur.homework.remainingTime;
+            remainingCount = cur.homework.remainingCount + cur.quiz.remainingCount;
+            url = '/std/lis/evltn/TaskStdPage.do';
+          }
+
+          return { remainingTime, remainingCount, totalCount, url };
+        })();
+
         acc += `
            <tr style="border-bottom: 1px solid #dce3eb; height: 30px">
              <td style="font-weight: bold">
@@ -317,14 +365,14 @@ export default () => {
                </span>
              </td>
              <td>
-               <span style="cursor: pointer" onclick="appModule.goLctrumBoard('/std/lis/evltn/TaskStdPage.do', '${cur.yearSemester}', '${cur.subjectCode}')">
-                 ${createContent('과제', cur.homework)}
-               <span>
+               <span style="cursor: pointer" onclick="appModule.goLctrumBoard('${homeworkMerged.url}', '${cur.yearSemester}', '${cur.subjectCode}')">
+                 ${createContent('과제', homeworkMerged)}
+               </span>
              </td>
              <td>
                <span style="cursor: pointer" onclick="appModule.goLctrumBoard('/std/lis/evltn/PrjctStdPage.do', '${cur.yearSemester}', '${cur.subjectCode}')">
                  ${createContent('팀 프로젝트', cur.teamProject)}
-               <span>
+               </span>
              </td>
            </tr>
          `;

--- a/src/routes/home.js
+++ b/src/routes/home.js
@@ -272,7 +272,7 @@ export default () => {
           const endDate = new Date(quiz.edt);
           const hourGap = Math.floor((endDate - nowDate) / 3600000);
 
-          if (hourGap < 0) {
+          if (!Number.isFinite(hourGap) || hourGap < 0) {
             continue;
           }
 


### PR DESCRIPTION
## 변경 사항

수강 과목 현황의 과제 칼럼에 퀴즈 마감 정보를 함께 표시하고, 클릭 시 가장 마감이 가까운 항목으로 동적 이동하도록 개선했습니다.

- `AnytmQuizStdList.do` API 호출을 추가하여 퀴즈 마감 정보를 수집
- 과제 칼럼에 퀴즈 totalCount를 합산하여 표시
- 퀴즈 마감이 과제보다 이른 경우 `AnytmQuizStdPage.do`로 동적 링크 이동
- 퀴즈와 과제 마감이 동점이거나 퀴즈가 없는 경우 기존 과제 페이지로 이동
- 기존 정렬 로직 버그 수정 (자기 자신 비교 → 전체 카테고리 최솟값 비교)

## 테스트 방법

1. 퀴즈가 미제출 상태인 과목의 과제 칼럼에 퀴즈 마감 정보가 표시되는지 확인
2. 퀴즈 마감이 과제보다 이른 경우 클릭 시 퀴즈 페이지로 이동하는지 확인
3. 퀴즈가 없거나 이미 제출된 경우 기존 과제 페이지로 이동하는지 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 홈 화면의 "수강 과목 현황"에 퀴즈 마감 현황을 추가하여 제출되지 않은 퀴즈의 남은 시간·남은 개수·총 개수를 표시합니다.
  * 퀴즈가 있는 경우 테이블에 퀴즈 열을 동적으로 추가해 각 과목별 퀴즈 정보를 표시합니다.
* **개선**
  * 마감 정렬 기준을 강의/과제/퀴즈/팀 프로젝트의 가장 빠른 마감으로 병합해 우선 표시하도록 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kw-service/klas-helper-extension/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->